### PR TITLE
remove binding.pry reference in modreport

### DIFF
--- a/examples/modlog_report_generator/modreport.rb
+++ b/examples/modlog_report_generator/modreport.rb
@@ -30,7 +30,7 @@ while (data[-1][:time] > Time.parse(start_date) ) do
     puts "Got #{data[-1][:time]}"
     sleep 2
   rescue
-    binding.pry
+    puts "Error in modlog. subreddit: #{subreddit} last: #{last} modlog #{modlog}"
   end
 end
 


### PR DESCRIPTION
Pry is not a dependency in your Gemfile. I'm assuming you used pry to just poke around, and it's not an essential part of snoo.

I am not a mod of reddit, so can't test out the mod functionality, but I'm assuming just doing a `puts` of the variables is suffice.
