### PR TITLE
set_cookies requires a string

### DIFF
--- a/lib/snoo/account.rb
+++ b/lib/snoo/account.rb
@@ -35,7 +35,7 @@ module Snoo
     # Logs out of a reddit account. This is usually uneeded, you can just log_in as a new account to replace the current one.
     # This just nils the cookies and modhash
     def log_out
-      set_cookies nil
+      set_cookies ""
       @modhash = nil
       @userid = nil
       @username = nil


### PR DESCRIPTION
This was causing:

```
/home/steven/.rvm/rubies/ruby-2.0.0-p195/lib/ruby/2.0.0/net/http/header.rb:17:in `block in initialize_http_header': undefined method `strip' for nil:NilClass (NoMethodError)
```

after logging out of one account and into another, since the cookies weren't a string.
