### PR TITLE
Add #set_subreddit_sticky method

### DIFF
--- a/lib/snoo/links_comments.rb
+++ b/lib/snoo/links_comments.rb
@@ -91,7 +91,7 @@ module Snoo
     # @return (see #clear_sessions)
     def set_subreddit_sticky id, state = true
       logged_in?
-      post('/api/set_subreddit_sticky', body: {id: id, state: state ? 'True' : 'False', uh: @modhash, api_type: 'json'})
+      post('/api/set_subreddit_sticky', body: {id: id, state: !!state, uh: @modhash, api_type: 'json'})
     end
 
     # Submit a link or self post


### PR DESCRIPTION
> Apologies to anyone that had started using the API to set posts as stickies, the method of setting it through settings will no longer work. There is a new API endpoint at /api/set_subreddit_sticky to set it now.

http://www.reddit.com/r/modnews/comments/1jwozg/moderators_there_is_now_a_button_on_the_comments/
